### PR TITLE
fix: strip directives off types, args, and enums

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -66,7 +66,7 @@ switch (cli.input[0]) {
     serveCommand(cli.flags);
     break;
   case "make-api-schema":
-    stripCommand(cli.flags);
+    console.log(stripCommand(cli.flags));
     break;
   default:
     console.error("invalid command");

--- a/test/strip.test.js
+++ b/test/strip.test.js
@@ -1,0 +1,26 @@
+import { stripCommand } from "../src/commands.js";
+
+test("make-api-schema", async () => {
+  const result = stripCommand({
+    schema: "test/__fixtures__/posts.graphql",
+    federated: true,
+  });
+
+  expect(result).toMatchInlineSnapshot(`
+"type Author {
+  id: ID
+  name: String
+}
+
+type Post {
+  id: ID
+  title: String
+  author: Author
+}
+
+type Query {
+  posts: [Post]
+}
+"
+`);
+});


### PR DESCRIPTION
in make-api-schema subcommand