### PR TITLE
fix: don't throw away arguments with mapArguments

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -97,7 +97,10 @@ async function resolveFetch(
   applyArgumentRenames(info, args);
 
   if (mapArguments) {
-    args = /** @type {TArgs} */ (convertInputArgs(mapArguments, source));
+    args = {
+      ...args,
+      .../** @type {TArgs} */ (convertInputArgs(mapArguments, source)),
+    };
   }
 
   const resp = await call(args);


### PR DESCRIPTION
this change merges the result of mapArguments with existing arguments