### PR TITLE
feat: enable ftv1 tracing by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@grpc/grpc-js": "^1.3.6",
     "@grpc/proto-loader": "^0.6.4",
     "apollo-server": "^3.0.2",
+    "apollo-server-core": "^3.0.2",
     "chokidar": "^3.5.2",
     "dataloader": "^2.0.0",
     "graphql": "^15.5.1",

--- a/src/commands.js
+++ b/src/commands.js
@@ -18,6 +18,7 @@ import {
   fromFederatedSDLToValidSDL,
   fromValidSDLToFederatedSDL,
 } from "@apollosolutions/federation-converter";
+import { ApolloServerPluginInlineTrace } from "apollo-server-core";
 
 const h = React.createElement;
 
@@ -147,6 +148,7 @@ export function serveCommand(flags) {
     context(args) {
       return args;
     },
+    plugins: [ApolloServerPluginInlineTrace()],
   })
     .listen({ port: flags.port ?? 4000 })
     .then(({ url }) => console.log(`Running GraphQL API at ${url}`));


### PR DESCRIPTION
according to the docs:
> Apollo Server installs this plugin by default in all federated subgraphs, with its default configuration. (Apollo Server decides that it is a federated subgraph if the schema it is serving includes a field _Service.sdl: String.)

this project doesn't support federated introspection so we need to enable the plugin ourselves